### PR TITLE
Add noop type to get around interface issues.

### DIFF
--- a/mock_test.go
+++ b/mock_test.go
@@ -337,6 +337,17 @@ func (s *MockSuite) TestMultiTimeSeriesTableDelete() {
 	s.Equal(RowNotFoundError{}, s.mtsTbl.Read("John", points[0].Time, points[0].Id, &p).Run())
 }
 
+func (s *MockSuite) TestNoop() {
+	s.insertUsers()
+	var users []user
+	op := Noop()
+	op = op.Add(s.mapTbl.MultiRead([]interface{}{1, 2}, &users))
+	s.NoError(op.Run())
+	s.Len(users, 2)
+	s.Equal("Jane", users[0].Name)
+	s.Equal("Jill", users[1].Name)
+}
+
 // Helper functions
 func (s *MockSuite) insertPoints() []point {
 	points := []point{

--- a/op.go
+++ b/op.go
@@ -16,6 +16,9 @@ const (
 	insert
 )
 
+type noop struct {
+}
+
 type op struct {
 	qe  QueryExecutor
 	ops []singleOp
@@ -94,10 +97,27 @@ func (w *singleOp) run(qe QueryExecutor, opt Options) error {
 
 // Noop returns an empty `Op` which is useful to conditionally add `Op`s to.
 func Noop() Op {
-	return &op{
-		qe:  nil,
-		ops: []singleOp{},
+	return &noop{}
+}
+
+func (w *noop) Add(wo ...Op) Op {
+	if len(wo) == 0 {
+		return w
 	}
+
+	return wo[0].Add(wo[1:]...)
+}
+
+func (w *noop) Run() error {
+	return nil
+}
+
+func (w *noop) RunAtomically() error {
+	return nil
+}
+
+func (w *noop) WithOptions(_ Options) Op {
+	return w
 }
 
 func (w *op) Add(wo ...Op) Op {


### PR DESCRIPTION
The bug was that `Noop()` returned an `op` so when using a mock keyspace it would panic because the Add method on the `op` struct type cast the `Op` to an `op` but it was actually a `mockOp`.