### PR TITLE
Bucket iteration support

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -1,0 +1,47 @@
+package gocassa
+
+import (
+	"time"
+)
+
+type bucketIter struct {
+	v         time.Time
+	step      time.Duration
+	field     string
+	invariant filter
+}
+
+func (b bucketIter) String() string {
+	return b.v.String()
+}
+
+func (b bucketIter) Bucket() time.Time {
+	step := b.step
+	if step < time.Second {
+		step = time.Second
+	}
+	secs := b.v.Unix()
+	return time.Unix((secs - secs%int64(step/time.Second)), 0)
+}
+
+func (b bucketIter) Next() Buckets {
+	return bucketIter{
+		v:         b.v.Add(b.step),
+		step:      b.step,
+		invariant: b.invariant,
+		field:     b.field}
+}
+
+func (b bucketIter) Prev() Buckets {
+	return bucketIter{
+		v:         b.v.Add(-b.step),
+		step:      b.step,
+		invariant: b.invariant,
+		field:     b.field}
+}
+
+func (b bucketIter) Filter() Filter {
+	rels := b.invariant.rs
+	rels = append(rels, Eq(b.field, b.Bucket()))
+	return b.invariant.t.Where(rels...)
+}

--- a/bucket.go
+++ b/bucket.go
@@ -14,7 +14,7 @@ type bucketIter struct {
 	v         time.Time
 	step      time.Duration
 	field     string
-	invariant filter
+	invariant Filter
 }
 
 func (b bucketIter) String() string {
@@ -47,7 +47,7 @@ func (b bucketIter) Prev() Buckets {
 }
 
 func (b bucketIter) Filter() Filter {
-	rels := b.invariant.rs
+	rels := b.invariant.Relations()
 	rels = append(rels, Eq(b.field, b.Bucket()))
-	return b.invariant.t.Where(rels...)
+	return b.invariant.Table().Where(rels...)
 }

--- a/bucket.go
+++ b/bucket.go
@@ -4,6 +4,12 @@ import (
 	"time"
 )
 
+func bucket(t time.Time, step time.Duration) time.Time {
+	return bucketIter{
+		v:    t,
+		step: step}.Bucket()
+}
+
 type bucketIter struct {
 	v         time.Time
 	step      time.Duration

--- a/filter.go
+++ b/filter.go
@@ -5,6 +5,10 @@ type filter struct {
 	rs []Relation
 }
 
+func (f filter) Table() Table {
+	return f.t
+}
+
 func (f filter) Update(m map[string]interface{}) Op {
 	return newWriteOp(f.t.keySpace.qe, f, updateOpType, m)
 }

--- a/filter.go
+++ b/filter.go
@@ -9,6 +9,10 @@ func (f filter) Table() Table {
 	return f.t
 }
 
+func (f filter) Relations() []Relation {
+	return f.rs
+}
+
 func (f filter) Update(m map[string]interface{}) Op {
 	return newWriteOp(f.t.keySpace.qe, f, updateOpType, m)
 }

--- a/flakeseries_table.go
+++ b/flakeseries_table.go
@@ -95,7 +95,7 @@ func (o *flakeSeriesT) Read(id string, pointer interface{}) Op {
 
 func (o *flakeSeriesT) List(startTime, endTime time.Time, pointerToASlice interface{}) Op {
 	buckets := []interface{}{}
-	for bucket := o.ListBucketed(startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+	for bucket := o.Buckets(startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
 		buckets = append(buckets, bucket.Bucket())
 	}
 	return o.Table().
@@ -105,7 +105,7 @@ func (o *flakeSeriesT) List(startTime, endTime time.Time, pointerToASlice interf
 		Read(pointerToASlice)
 }
 
-func (o *flakeSeriesT) ListBucketed(start time.Time) Buckets {
+func (o *flakeSeriesT) Buckets(start time.Time) Buckets {
 	return bucketIter{
 		v:         start,
 		step:      o.bucketSize,
@@ -128,7 +128,7 @@ func (o *flakeSeriesT) ListSince(id string, window time.Duration, pointerToASlic
 	}
 
 	buckets := []interface{}{}
-	for bucket := o.ListBucketed(startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+	for bucket := o.Buckets(startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
 		buckets = append(buckets, bucket.Bucket())
 	}
 

--- a/flakeseries_table.go
+++ b/flakeseries_table.go
@@ -47,7 +47,7 @@ func (o *flakeSeriesT) Set(v interface{}) Op {
 	}
 
 	m[flakeTimestampFieldName] = timestamp
-	m[bucketFieldName] = o.bucket(timestamp.Unix())
+	m[bucketFieldName] = bucket(timestamp, o.bucketSize)
 
 	return o.Table().Set(m)
 }
@@ -57,7 +57,7 @@ func (o *flakeSeriesT) Update(id string, m map[string]interface{}) Op {
 	if err != nil {
 		return errOp{err: err}
 	}
-	bucket := o.bucket(timestamp.Unix())
+	bucket := bucket(timestamp, o.bucketSize)
 
 	return o.Table().
 		Where(Eq(bucketFieldName, bucket),
@@ -71,7 +71,7 @@ func (o *flakeSeriesT) Delete(id string) Op {
 	if err != nil {
 		return errOp{err: err}
 	}
-	bucket := o.bucket(timestamp.Unix())
+	bucket := bucket(timestamp, o.bucketSize)
 
 	return o.Table().
 		Where(Eq(bucketFieldName, bucket),
@@ -85,7 +85,7 @@ func (o *flakeSeriesT) Read(id string, pointer interface{}) Op {
 	if err != nil {
 		return errOp{err: err}
 	}
-	bucket := o.bucket(timestamp.Unix())
+	bucket := bucket(timestamp, o.bucketSize)
 	return o.Table().
 		Where(Eq(bucketFieldName, bucket),
 			Eq(flakeTimestampFieldName, timestamp),
@@ -94,12 +94,23 @@ func (o *flakeSeriesT) Read(id string, pointer interface{}) Op {
 }
 
 func (o *flakeSeriesT) List(startTime, endTime time.Time, pointerToASlice interface{}) Op {
-	buckets := o.buckets(startTime, endTime)
+	buckets := []interface{}{}
+	for bucket := o.ListBucketed(startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+		buckets = append(buckets, bucket.Bucket())
+	}
 	return o.Table().
 		Where(In(bucketFieldName, buckets...),
 			GTE(flakeTimestampFieldName, startTime),
 			LT(flakeTimestampFieldName, endTime)).
 		Read(pointerToASlice)
+}
+
+func (o *flakeSeriesT) ListBucketed(start time.Time) Buckets {
+	return bucketIter{
+		v:         start,
+		step:      o.bucketSize,
+		field:     bucketFieldName,
+		invariant: o.Table().Where().(filter)}
 }
 
 func (o *flakeSeriesT) ListSince(id string, window time.Duration, pointerToASlice interface{}) Op {
@@ -109,14 +120,18 @@ func (o *flakeSeriesT) ListSince(id string, window time.Duration, pointerToASlic
 	}
 
 	var endTime time.Time
-
 	if window == 0 {
 		// no window set - so go up until 5 mins in the future
 		endTime = time.Now().Add(5 * time.Minute)
 	} else {
 		endTime = startTime.Add(window)
 	}
-	buckets := o.buckets(startTime, endTime)
+
+	buckets := []interface{}{}
+	for bucket := o.ListBucketed(startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+		buckets = append(buckets, bucket.Bucket())
+	}
+
 	return o.Table().
 		Where(In(bucketFieldName, buckets),
 			GTE(flakeTimestampFieldName, startTime),
@@ -130,20 +145,6 @@ func (o *flakeSeriesT) WithOptions(opt Options) FlakeSeriesTable {
 		t:          o.Table().WithOptions(opt),
 		idField:    o.idField,
 		bucketSize: o.bucketSize}
-}
-
-func (o *flakeSeriesT) buckets(startTime, endTime time.Time) []interface{} {
-	buckets := []interface{}{}
-	start := o.bucket(startTime.Unix())
-	for i := start; i < endTime.Unix()*1000; i += int64(o.bucketSize/time.Second) * 1000 {
-		buckets = append(buckets, i)
-	}
-
-	return buckets
-}
-
-func (o *flakeSeriesT) bucket(secs int64) int64 {
-	return (secs - secs%int64(o.bucketSize/time.Second)) * 1000
 }
 
 func flakeToTime(id string) (time.Time, error) {

--- a/flakeseries_table.go
+++ b/flakeseries_table.go
@@ -110,7 +110,7 @@ func (o *flakeSeriesT) ListBucketed(start time.Time) Buckets {
 		v:         start,
 		step:      o.bucketSize,
 		field:     bucketFieldName,
-		invariant: o.Table().Where().(filter)}
+		invariant: o.Table().Where()}
 }
 
 func (o *flakeSeriesT) ListSince(id string, window time.Duration, pointerToASlice interface{}) Op {

--- a/flakeseries_table_test.go
+++ b/flakeseries_table_test.go
@@ -16,7 +16,7 @@ func timeToFlake(t *testing.T, time string) string {
 	return "id_" + base62.EncodeBigInt(bf)
 }
 
-func TestFlakeSeriesT(t *testing.T) {
+func TestFlakeSeriesTable(t *testing.T) {
 	tbl := ns.FlakeSeriesTable("tripFlake5", "Id", time.Minute, Trip{})
 	createIf(tbl.(TableChanger), t)
 	id1 := timeToFlake(t, "2006 Jan 2 15:03:59")

--- a/interfaces.go
+++ b/interfaces.go
@@ -150,14 +150,16 @@ type MultiFlakeSeriesTable interface {
 // Filter is a subset of a Table, filtered by Relations.
 // You can do writes or reads on a filter.
 type Filter interface {
-	// Updates does a partial update. Use this if you don't want to overwrite your whole row, but you want to modify fields atomically.
+	// Update does a partial update. Use this if you don't want to overwrite your whole row, but you want to modify fields atomically.
 	Update(m map[string]interface{}) Op // Probably this is danger zone (can't be implemented efficiently) on a selectuinb with more than 1 document
 	// Delete all rows matching the filter.
 	Delete() Op
-	// Read the results. Make sure you pass in a pointer to a slice.
+	// Reads all results. Make sure you pass in a pointer to a slice.
 	Read(pointerToASlice interface{}) Op
-	// Read one result. Make sure you pass in a pointer.
+	// ReadOne reads a single result. Make sure you pass in a pointer.
 	ReadOne(pointer interface{}) Op
+	// Table on which this filter operates.
+	Table() Table
 }
 
 // Keys is used with the raw CQL Table type. It is implicit when using recipe tables.
@@ -245,3 +247,10 @@ type QueryExecutor interface {
 }
 
 type Counter int
+
+type Buckets interface {
+	Filter() Filter
+	Bucket() time.Time
+	Next() Buckets
+	Prev() Buckets
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -110,6 +110,7 @@ type MultiTimeSeriesTable interface {
 	Delete(v interface{}, timeStamp time.Time, id interface{}) Op
 	Read(v interface{}, timeStamp time.Time, id, pointer interface{}) Op
 	List(v interface{}, start, end time.Time, pointerToASlice interface{}) Op
+	ListBucketed(v interface{}, start time.Time) Buckets
 	WithOptions(Options) MultiTimeSeriesTable
 	Table() Table
 	TableChanger

--- a/interfaces.go
+++ b/interfaces.go
@@ -123,7 +123,7 @@ type FlakeSeriesTable interface {
 	Delete(id string) Op
 	Read(id string, pointer interface{}) Op
 	List(start, end time.Time, pointerToASlice interface{}) Op
-	// ListBucketed(v interface{}, start time.Time) Buckets
+	ListBucketed(start time.Time) Buckets
 	// ListSince queries the flakeSeries for the items after the specified ID but within the time window,
 	// if the time window is zero then it lists up until 5 minutes in the future
 	ListSince(id string, window time.Duration, pointerToASlice interface{}) Op

--- a/interfaces.go
+++ b/interfaces.go
@@ -93,6 +93,7 @@ type TimeSeriesTable interface {
 	Delete(timeStamp time.Time, id interface{}) Op
 	Read(timeStamp time.Time, id, pointer interface{}) Op
 	List(start, end time.Time, pointerToASlice interface{}) Op
+	ListBucketed(start time.Time) Buckets
 	WithOptions(Options) TimeSeriesTable
 	Table() Table
 	TableChanger
@@ -122,6 +123,7 @@ type FlakeSeriesTable interface {
 	Delete(id string) Op
 	Read(id string, pointer interface{}) Op
 	List(start, end time.Time, pointerToASlice interface{}) Op
+	// ListBucketed(v interface{}, start time.Time) Buckets
 	// ListSince queries the flakeSeries for the items after the specified ID but within the time window,
 	// if the time window is zero then it lists up until 5 minutes in the future
 	ListSince(id string, window time.Duration, pointerToASlice interface{}) Op
@@ -136,6 +138,7 @@ type MultiFlakeSeriesTable interface {
 	Delete(v interface{}, id string) Op
 	Read(v interface{}, id string, pointer interface{}) Op
 	List(v interface{}, start, end time.Time, pointerToASlice interface{}) Op
+	// ListBucketed(v interface{}, start time.Time) Buckets
 	// ListSince queries the flakeSeries for the items after the specified ID but within the time window,
 	// if the time window is zero then it lists up until 5 minutes in the future
 	ListSince(v interface{}, id string, window time.Duration, pointerToASlice interface{}) Op

--- a/interfaces.go
+++ b/interfaces.go
@@ -93,7 +93,7 @@ type TimeSeriesTable interface {
 	Delete(timeStamp time.Time, id interface{}) Op
 	Read(timeStamp time.Time, id, pointer interface{}) Op
 	List(start, end time.Time, pointerToASlice interface{}) Op
-	ListBucketed(start time.Time) Buckets
+	Buckets(start time.Time) Buckets
 	WithOptions(Options) TimeSeriesTable
 	Table() Table
 	TableChanger
@@ -111,7 +111,7 @@ type MultiTimeSeriesTable interface {
 	Delete(v interface{}, timeStamp time.Time, id interface{}) Op
 	Read(v interface{}, timeStamp time.Time, id, pointer interface{}) Op
 	List(v interface{}, start, end time.Time, pointerToASlice interface{}) Op
-	ListBucketed(v interface{}, start time.Time) Buckets
+	Buckets(v interface{}, start time.Time) Buckets
 	WithOptions(Options) MultiTimeSeriesTable
 	Table() Table
 	TableChanger
@@ -123,7 +123,7 @@ type FlakeSeriesTable interface {
 	Delete(id string) Op
 	Read(id string, pointer interface{}) Op
 	List(start, end time.Time, pointerToASlice interface{}) Op
-	ListBucketed(start time.Time) Buckets
+	Buckets(start time.Time) Buckets
 	// ListSince queries the flakeSeries for the items after the specified ID but within the time window,
 	// if the time window is zero then it lists up until 5 minutes in the future
 	ListSince(id string, window time.Duration, pointerToASlice interface{}) Op
@@ -138,7 +138,7 @@ type MultiFlakeSeriesTable interface {
 	Delete(v interface{}, id string) Op
 	Read(v interface{}, id string, pointer interface{}) Op
 	List(v interface{}, start, end time.Time, pointerToASlice interface{}) Op
-	ListBucketed(v interface{}, start time.Time) Buckets
+	Buckets(v interface{}, start time.Time) Buckets
 	// ListSince queries the flakeSeries for the items after the specified ID but within the time window,
 	// if the time window is zero then it lists up until 5 minutes in the future
 	ListSince(v interface{}, id string, window time.Duration, pointerToASlice interface{}) Op
@@ -254,6 +254,7 @@ type QueryExecutor interface {
 
 type Counter int
 
+// Buckets is an iterator over a timeseries' buckets
 type Buckets interface {
 	Filter() Filter
 	Bucket() time.Time

--- a/interfaces.go
+++ b/interfaces.go
@@ -164,6 +164,8 @@ type Filter interface {
 	ReadOne(pointer interface{}) Op
 	// Table on which this filter operates.
 	Table() Table
+	// Relations which make up this filter. These should not be modified.
+	Relations() []Relation
 }
 
 // Keys is used with the raw CQL Table type. It is implicit when using recipe tables.

--- a/interfaces.go
+++ b/interfaces.go
@@ -138,7 +138,7 @@ type MultiFlakeSeriesTable interface {
 	Delete(v interface{}, id string) Op
 	Read(v interface{}, id string, pointer interface{}) Op
 	List(v interface{}, start, end time.Time, pointerToASlice interface{}) Op
-	// ListBucketed(v interface{}, start time.Time) Buckets
+	ListBucketed(v interface{}, start time.Time) Buckets
 	// ListSince queries the flakeSeries for the items after the specified ID but within the time window,
 	// if the time window is zero then it lists up until 5 minutes in the future
 	ListSince(v interface{}, id string, window time.Duration, pointerToASlice interface{}) Op

--- a/mock.go
+++ b/mock.go
@@ -307,6 +307,10 @@ type MockFilter struct {
 	relations []Relation
 }
 
+func (f *MockFilter) Table() Table {
+	return f.table
+}
+
 func (f *MockFilter) rowMatch(row map[string]interface{}) bool {
 	for _, relation := range f.relations {
 		value := row[relation.key]

--- a/mock.go
+++ b/mock.go
@@ -311,6 +311,10 @@ func (f *MockFilter) Table() Table {
 	return f.table
 }
 
+func (f *MockFilter) Relations() []Relation {
+	return f.relations
+}
+
 func (f *MockFilter) rowMatch(row map[string]interface{}) bool {
 	for _, relation := range f.relations {
 		value := row[relation.key]

--- a/multiflakeseries_table.go
+++ b/multiflakeseries_table.go
@@ -90,7 +90,7 @@ func (o *multiFlakeSeriesT) Read(v interface{}, id string, pointer interface{}) 
 
 func (o *multiFlakeSeriesT) List(v interface{}, startTime, endTime time.Time, pointerToASlice interface{}) Op {
 	buckets := []interface{}{}
-	for bucket := o.ListBucketed(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+	for bucket := o.Buckets(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
 		buckets = append(buckets, bucket.Bucket())
 	}
 	return o.Table().
@@ -101,7 +101,7 @@ func (o *multiFlakeSeriesT) List(v interface{}, startTime, endTime time.Time, po
 		Read(pointerToASlice)
 }
 
-func (o *multiFlakeSeriesT) ListBucketed(v interface{}, start time.Time) Buckets {
+func (o *multiFlakeSeriesT) Buckets(v interface{}, start time.Time) Buckets {
 	return bucketIter{
 		v:         start,
 		step:      o.bucketSize,
@@ -124,7 +124,7 @@ func (o *multiFlakeSeriesT) ListSince(v interface{}, id string, window time.Dura
 	}
 
 	buckets := []interface{}{}
-	for bucket := o.ListBucketed(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+	for bucket := o.Buckets(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
 		buckets = append(buckets, bucket.Bucket())
 	}
 

--- a/multiflakeseries_table.go
+++ b/multiflakeseries_table.go
@@ -106,7 +106,7 @@ func (o *multiFlakeSeriesT) ListBucketed(v interface{}, start time.Time) Buckets
 		v:         start,
 		step:      o.bucketSize,
 		field:     bucketFieldName,
-		invariant: o.Table().Where(Eq(o.indexField, v)).(filter)}
+		invariant: o.Table().Where(Eq(o.indexField, v))}
 }
 
 func (o *multiFlakeSeriesT) ListSince(v interface{}, id string, window time.Duration, pointerToASlice interface{}) Op {

--- a/multiflakeseries_table.go
+++ b/multiflakeseries_table.go
@@ -38,7 +38,7 @@ func (o *multiFlakeSeriesT) Set(v interface{}) Op {
 	}
 
 	m[flakeTimestampFieldName] = timestamp
-	m[bucketFieldName] = o.bucket(timestamp.Unix())
+	m[bucketFieldName] = bucket(timestamp, o.bucketSize)
 
 	return o.Table().
 		Set(m)
@@ -49,7 +49,7 @@ func (o *multiFlakeSeriesT) Update(v interface{}, id string, m map[string]interf
 	if err != nil {
 		return errOp{err: err}
 	}
-	bucket := o.bucket(timestamp.Unix())
+	bucket := bucket(timestamp, o.bucketSize)
 
 	return o.Table().
 		Where(Eq(o.indexField, v),
@@ -64,7 +64,7 @@ func (o *multiFlakeSeriesT) Delete(v interface{}, id string) Op {
 	if err != nil {
 		return errOp{err: err}
 	}
-	bucket := o.bucket(timestamp.Unix())
+	bucket := bucket(timestamp, o.bucketSize)
 
 	return o.Table().
 		Where(Eq(o.indexField, v),
@@ -79,7 +79,7 @@ func (o *multiFlakeSeriesT) Read(v interface{}, id string, pointer interface{}) 
 	if err != nil {
 		return errOp{err: err}
 	}
-	bucket := o.bucket(timestamp.Unix())
+	bucket := bucket(timestamp, o.bucketSize)
 	return o.Table().
 		Where(Eq(o.indexField, v),
 			Eq(bucketFieldName, bucket),
@@ -89,13 +89,24 @@ func (o *multiFlakeSeriesT) Read(v interface{}, id string, pointer interface{}) 
 }
 
 func (o *multiFlakeSeriesT) List(v interface{}, startTime, endTime time.Time, pointerToASlice interface{}) Op {
-	buckets := o.buckets(startTime, endTime)
+	buckets := []interface{}{}
+	for bucket := o.ListBucketed(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+		buckets = append(buckets, bucket.Bucket())
+	}
 	return o.Table().
 		Where(Eq(o.indexField, v),
 			In(bucketFieldName, buckets...),
 			GTE(flakeTimestampFieldName, startTime),
 			LT(flakeTimestampFieldName, endTime)).
 		Read(pointerToASlice)
+}
+
+func (o *multiFlakeSeriesT) ListBucketed(v interface{}, start time.Time) Buckets {
+	return bucketIter{
+		v:         start,
+		step:      o.bucketSize,
+		field:     bucketFieldName,
+		invariant: o.Table().Where(Eq(o.indexField, v)).(filter)}
 }
 
 func (o *multiFlakeSeriesT) ListSince(v interface{}, id string, window time.Duration, pointerToASlice interface{}) Op {
@@ -105,14 +116,18 @@ func (o *multiFlakeSeriesT) ListSince(v interface{}, id string, window time.Dura
 	}
 
 	var endTime time.Time
-
 	if window == 0 {
 		// no window set - so go up until 5 mins in the future
 		endTime = time.Now().Add(5 * time.Minute)
 	} else {
 		endTime = startTime.Add(window)
 	}
-	buckets := o.buckets(startTime, endTime)
+
+	buckets := []interface{}{}
+	for bucket := o.ListBucketed(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+		buckets = append(buckets, bucket.Bucket())
+	}
+
 	return o.Table().
 		Where(Eq(o.indexField, v),
 			In(bucketFieldName, buckets),
@@ -129,18 +144,4 @@ func (o *multiFlakeSeriesT) WithOptions(opt Options) MultiFlakeSeriesTable {
 		idField:    o.idField,
 		bucketSize: o.bucketSize,
 	}
-}
-
-func (o *multiFlakeSeriesT) buckets(startTime, endTime time.Time) []interface{} {
-	buckets := []interface{}{}
-	start := o.bucket(startTime.Unix())
-	for i := start; i < endTime.Unix()*1000; i += int64(o.bucketSize/time.Second) * 1000 {
-		buckets = append(buckets, i)
-	}
-
-	return buckets
-}
-
-func (o *multiFlakeSeriesT) bucket(secs int64) int64 {
-	return (secs - secs%int64(o.bucketSize/time.Second)) * 1000
 }

--- a/multiflakeseries_table_test.go
+++ b/multiflakeseries_table_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestMultiFlakeSeriesT(t *testing.T) {
+func TestMultiFlakeSeriesTable(t *testing.T) {
 	tbl := ns.MultiFlakeSeriesTable("tripFlake6", "Tag", "Id", time.Minute, TripB{})
 	createIf(tbl.(TableChanger), t)
 	id1 := timeToFlake(t, "2006 Jan 2 15:03:59")

--- a/multitimeseries_table.go
+++ b/multitimeseries_table.go
@@ -69,7 +69,7 @@ func (o *multiTimeSeriesT) Read(v interface{}, timeStamp time.Time, id, pointer 
 
 func (o *multiTimeSeriesT) List(v interface{}, startTime time.Time, endTime time.Time, pointerToASlice interface{}) Op {
 	buckets := []interface{}{}
-	for bucket := o.ListBucketed(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+	for bucket := o.Buckets(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
 		buckets = append(buckets, bucket.Bucket())
 	}
 	return o.Table().
@@ -80,7 +80,7 @@ func (o *multiTimeSeriesT) List(v interface{}, startTime time.Time, endTime time
 		Read(pointerToASlice)
 }
 
-func (o *multiTimeSeriesT) ListBucketed(v interface{}, start time.Time) Buckets {
+func (o *multiTimeSeriesT) Buckets(v interface{}, start time.Time) Buckets {
 	return bucketIter{
 		v:         start,
 		step:      o.bucketSize,

--- a/multitimeseries_table.go
+++ b/multitimeseries_table.go
@@ -85,7 +85,7 @@ func (o *multiTimeSeriesT) ListBucketed(v interface{}, start time.Time) Buckets 
 		v:         start,
 		step:      o.bucketSize,
 		field:     bucketFieldName,
-		invariant: o.Table().Where(Eq(o.indexField, v)).(filter)}
+		invariant: o.Table().Where(Eq(o.indexField, v))}
 }
 
 func (o *multiTimeSeriesT) WithOptions(opt Options) MultiTimeSeriesTable {

--- a/timeseries_table.go
+++ b/timeseries_table.go
@@ -80,7 +80,7 @@ func (o *timeSeriesT) ListBucketed(start time.Time) Buckets {
 		v:         start,
 		step:      o.bucketSize,
 		field:     bucketFieldName,
-		invariant: o.Table().Where().(filter)}
+		invariant: o.Table().Where()}
 }
 
 func (o *timeSeriesT) WithOptions(opt Options) TimeSeriesTable {

--- a/timeseries_table.go
+++ b/timeseries_table.go
@@ -65,7 +65,7 @@ func (o *timeSeriesT) Read(timeStamp time.Time, id, pointer interface{}) Op {
 
 func (o *timeSeriesT) List(startTime time.Time, endTime time.Time, pointerToASlice interface{}) Op {
 	buckets := []interface{}{}
-	for bucket := o.ListBucketed(startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+	for bucket := o.Buckets(startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
 		buckets = append(buckets, bucket.Bucket())
 	}
 	return o.Table().
@@ -75,7 +75,7 @@ func (o *timeSeriesT) List(startTime time.Time, endTime time.Time, pointerToASli
 		Read(pointerToASlice)
 }
 
-func (o *timeSeriesT) ListBucketed(start time.Time) Buckets {
+func (o *timeSeriesT) Buckets(start time.Time) Buckets {
 	return bucketIter{
 		v:         start,
 		step:      o.bucketSize,

--- a/timeseries_table_test.go
+++ b/timeseries_table_test.go
@@ -22,7 +22,7 @@ func parse(value string) time.Time {
 	return t
 }
 
-func TestTimeSeriesT(t *testing.T) {
+func TestTimeSeriesTable(t *testing.T) {
 	tbl := ns.TimeSeriesTable("tripTime5", "Time", "Id", time.Minute, Trip{})
 	createIf(tbl.(TableChanger), t)
 	err := tbl.Set(Trip{


### PR DESCRIPTION
This adds support for the "bucket iteration" pattern, where a client queries each bucket successively until it has enough results. The interface supports forward and backward iteration, with an interface similar to those found in the [Go stdlib](https://golang.org/pkg/container/list/#Element).

```go
type Buckets interface {
 	Filter() Filter
 	Bucket() time.Time
 	Next() Buckets
 	Prev() Buckets
 }
```

Of course, this pattern should be used cautiously – it requires enough nodes are available to achieve the desired consistency level for _every_ bucket iterated over.

The internal code paths like `List` have been refactored to use bucket iteration under the covers, though these use the buckets to construct an `IN` query rather than sequentially iterating in the client.

<img src="https://media.giphy.com/media/14aumMYgx9CvKw/giphy.gif">