### PR TITLE
Return error if no query executor is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
 
 go:
-  - 1.4
   - 1.5
+  - 1.6
+  - 1.6.1
+  - 1.6.2
   - tip
 
 services:

--- a/keyspace.go
+++ b/keyspace.go
@@ -174,6 +174,11 @@ func (k *k) MultiFlakeSeriesTable(name, indexField, idField string, bucketSize t
 // Returns table names in a keyspace
 func (k *k) Tables() ([]string, error) {
 	const stmt = "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name = ?"
+
+	if k.qe == nil {
+		return nil, fmt.Errorf("no query executor configured")
+	}
+
 	maps, err := k.qe.Query(stmt, k.name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Returns an error rather than panicing if there is no `QueryExecutor` available. This "fixes" the case where we use a mock during testing, which doesn't have a query executor, and therefore panics.